### PR TITLE
Add cronjob / redis process for updating leaderboard

### DIFF
--- a/.foreman
+++ b/.foreman
@@ -1,1 +1,1 @@
-formation: traefik=1,validations=1,checkings=1,stats=3
+formation: traefik=1,validations=1,checkings=1,stats=3,redis=1

--- a/Procfile
+++ b/Procfile
@@ -2,3 +2,4 @@ traefik: ./proxy/traefik --configFile=./proxy/traefik.toml
 checkings: uvicorn --port $CHECKING_PORT --app-dir="./api" checking_service:app --reload --root-path /api/checkings
 validations: uvicorn --port $VALIDATION_PORT --app-dir="./api" validation_service:app --reload --root-path /api/validations
 stats: uvicorn --port $PORT --app-dir="./api" statistics_service:app --reload --root-path /api/statistics
+redis: redis-server

--- a/bin/cron.txt
+++ b/bin/cron.txt
@@ -1,0 +1,1 @@
+*/10 * * * * . ~/.bash_profile && run-one bash -l $($PROJ_PATH/bin/leaderboard.sh >> $PROJ_PATH/var/log/cron.log 2>&1)

--- a/bin/init.sh
+++ b/bin/init.sh
@@ -7,4 +7,4 @@ echo "export PROJ_PATH=$(pwd)" >> ~/.bash_profile && . ~/.bash_profile
 # pyinstaller --onefile $PROJ_PATH/bin/python/getTop10.py
 
 # start cronjob
-crontab $PROJ_PATH/bin/cron.leaderboard.txt
+crontab $PROJ_PATH/bin/cron.txt

--- a/bin/init.sh
+++ b/bin/init.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+# add project directory to env variable for cron
+echo "export PROJ_PATH=$(pwd)" >> ~/.bash_profile && . ~/.bash_profile
+
+# TODO: build standalone app
+# pyinstaller --onefile $PROJ_PATH/bin/python/getTop10.py
+
+# start cronjob
+crontab $PROJ_PATH/bin/cron.leaderboard.txt

--- a/bin/leaderboard.sh
+++ b/bin/leaderboard.sh
@@ -1,0 +1,4 @@
+. ~/.bash_profile && \
+echo "Update Leaderboard: $(date)" && \
+# getTop10 - standalone program placeholder name
+$PROJ_PATH/dist/getTop10 | redis-cli --pipe 


### PR DESCRIPTION
## PR Checklist

#### Tests

- [x] tested services
  - [x] functions working for this feature
  - [ ] autodocumentation works
- [ ] tested configuration
  - [ ] launches services
  - [ ] reverse proxy
  - [ ] load balancing
  - [x] runs cron job

#### Design Requirements

- [ ] input/output representations in json format

- [ ] maintains statelessness (independent services)
  - [ ] separate python files for each service
  - [ ] doesn't store current day's answer on the server side
  - [ ] doesn't track number of guesses made by a client

#### Readability / Maintainability

- [x] commented code
- [x] follows PEP8 style / passes linting checks

## Description

Closes #2, closes #3 

#### Changes

- add redis to foreman
- add cronjob for updating leaderboard in redis from CLI program
